### PR TITLE
feat: minor precommit fixes - changed ruff parameters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,25 @@
+default_language_version:
+  python: python3.10
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.0
+    hooks:
+      - id: ruff
+        types_or: [python, pyi, jupyter, toml]
+        args: [--fix, --show-fixes]
+      - id: ruff-format
+        types_or: [python, pyi, jupyter, toml]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        args: [--write]
+        types_or: [yaml, markdown, json]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: [--write-changes]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
@@ -10,34 +31,12 @@ repos:
         args: ["--maxkb=3000"]
       - id: check-ast
       - id: check-yaml
+      - id: check-toml
       - id: check-json
       - id: check-merge-conflict
       - id: detect-private-key
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.9
-    hooks:
-      - id: ruff
-        types_or: [python, pyi, jupyter]
-        args: [--fix, --show-fixes]
-      - id: ruff-format
-        types_or: [python, pyi, jupyter]
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        args: [--write]
-        types_or: [yaml, markdown, html, css, scss, javascript, json]
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
-    hooks:
-      - id: codespell
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.16.0
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.10.1
     hooks:
       - id: mypy
         args: [--config-file=pyproject.toml]


### PR DESCRIPTION
I rearranged the pre-commits to run those that fix issues first and checks later. However, the problem persists even with the correct flags set. For example, with Ruff, the `--fix` flag should return `0` if it fixes issues, but it returns `1`. I'm not sure why this happens, as the `--exit-non-zero-on-fix` flag should handle this behavior, but we don't use this flag and still encounter this behaviour.

I also added all necessary flags for each formatter to attempt fixes where possible and specified the Python version for reproducibility. In my opinion, @Fersoil, you can check and try it, but I've already done this. My advice is to leave it as it is (maybe remove the later pre-commits) and, at most, write an issue on the Ruff repository page.