### PR TITLE
fix: add rotation change to the HSI image visualization

### DIFF
--- a/src/meteors/visualize/lime_visualize.py
+++ b/src/meteors/visualize/lime_visualize.py
@@ -39,6 +39,8 @@ def visualize_hsi(hsi: HSI | HSIAttributes, ax: Axes | None, use_mask: bool = Tr
     if isinstance(hsi, HSIAttributes):
         hsi = hsi.hsi
 
+    hsi = hsi.change_orientation("HWC", inplace=False)
+
     rgb = hsi.get_rgb_image(output_channel_axis=2, apply_mask=use_mask).cpu().numpy()
     ax = ax or plt.gca()
     ax.imshow(rgb)


### PR DESCRIPTION
Simple modification of the HSI image plotting that ensures that the image has the correct rotation