### PR TITLE
fix: changelog.md and release notes do not contain all commits due to the commit processor not parsing multi-line commit messages.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,10 +3,25 @@
 ## v0.1.0 (2024-10-29)
 
 ### 🛎️ Chores
+
 - update the project version (#112)
+- reduced coverage threshold (#94)
+
+### 🔨 Features
+
+- 96 feat segmentation support for attribution methods (#103)
+- refactored the package structure (#111)
+- Custom errors (#101)
 
 ### 🩺 Bug Fixes
+
+- corrected visualizations (#106)
+- Updated occlusion (#93)
 - 91 docs the lime illustration image is missing in the docs (#92)
+
+### 📚 Documentation
+
+- update changelog.md for 0.0.4 [skip ci] (#90)
 
 ## v0.0.4 (2024-09-25)
 

--- a/commit_processor.py
+++ b/commit_processor.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 
 def parse_commit(commit: Commit) -> tuple[str | None, str]:
-    pattern = r"^(\w+): (.+)$"
+    pattern = r"^(\w+): ([^\n]+)"
     match = re.match(pattern, commit.message.strip())
     if match:
         return match.groups()  # type: ignore


### PR DESCRIPTION
Fixed issue #115 