### PR TITLE
feat: Updating Rye and preparing for shifting to uv

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,10 @@ jobs:
 
       - name: Setup Rye 🌾
         id: setup-rye
-        uses: eifinger/setup-rye@v3
+        uses: eifinger/setup-rye@v4
         with:
-          version: "0.35.0"
+          enable-cache: true
+          version: "0.42.0"
 
       - name: Pin python-version 3.10 📌
         run: rye pin 3.10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,9 +21,10 @@ jobs:
 
       - name: Setup Rye 🌾
         id: setup-rye
-        uses: eifinger/setup-rye@v3
+        uses: eifinger/setup-rye@v4
         with:
-          version: "0.35.0"
+          enable-cache: true
+          version: "0.42.0"
 
       - name: Pin python-version 3.10 📌
         run: rye pin 3.10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  RYE_VERSION: "0.39.0"
+  RYE_VERSION: "0.42.0"
   DRY_RUN: ${{ github.event.inputs.dry-run }}
 
 jobs:
@@ -46,8 +46,9 @@ jobs:
           fi
 
       - name: Setup Rye 🌾
-        uses: eifinger/setup-rye@v3
+        uses: eifinger/setup-rye@v4
         with:
+          enable-cache: true
           version: ${{ env.RYE_VERSION }}
 
       - name: Pin python-version 📌
@@ -99,8 +100,9 @@ jobs:
 
       - name: Setup Rye 🌾
         id: setup-rye
-        uses: eifinger/setup-rye@v3
+        uses: eifinger/setup-rye@v4
         with:
+          enable-cache: true
           version: ${{ env.RYE_VERSION }}
 
       - name: Pin python-version 📌
@@ -175,8 +177,9 @@ jobs:
 
       - name: Setup Rye 🌾
         id: setup-rye
-        uses: eifinger/setup-rye@v3
+        uses: eifinger/setup-rye@v4
         with:
+          enable-cache: true
           version: ${{ env.RYE_VERSION }}
 
       - name: Pin python-version 📌
@@ -233,8 +236,9 @@ jobs:
 
       - name: Setup Rye 🌾
         id: setup-rye
-        uses: eifinger/setup-rye@v3
+        uses: eifinger/setup-rye@v4
         with:
+          enable-cache: true
           version: ${{ env.RYE_VERSION }}
 
       - name: Pin python-version 📌
@@ -289,8 +293,9 @@ jobs:
 
       - name: Setup Rye 🌾
         id: setup-rye
-        uses: eifinger/setup-rye@v3
+        uses: eifinger/setup-rye@v4
         with:
+          enable-cache: true
           version: ${{ env.RYE_VERSION }}
 
       - name: Pin python-version 📌

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,10 @@ jobs:
 
       - name: Setup Rye 🌾
         id: setup-rye
-        uses: eifinger/setup-rye@v3
+        uses: eifinger/setup-rye@v4
         with:
-          version: "0.35.0"
+          enable-cache: true
+          version: "0.42.0"
 
       - name: Pin python-version ${{ matrix.python-version }} 📌
         run: rye pin ${{ matrix.python-version }}

--- a/changelog.md
+++ b/changelog.md
@@ -3,12 +3,15 @@
 ## v0.1.2 (2024-11-21)
 
 ### 🛎️ Chores
+
 - update the package version ([#142](https://github.com/xai4space/meteors/pull/142))
 
 ### 🩺 Bug Fixes
+
 - documentation version alias update fixed ([#139](https://github.com/xai4space/meteors/pull/139))
 
 ### 📚 Documentation
+
 - tutorials fixes ([#129](https://github.com/xai4space/meteors/pull/129))
 - fixed documentation versioning ([#135](https://github.com/xai4space/meteors/pull/135))
 - Documentation template update ([#134](https://github.com/xai4space/meteors/pull/134))
@@ -17,6 +20,7 @@
 - update changelog.md for v0.1.1 [skip ci] ([#131](https://github.com/xai4space/meteors/pull/131))
 
 ### 🔨 Features
+
 - Added Hyperlinks to the PR in changelog ([#136](https://github.com/xai4space/meteors/pull/136))
 
 ## v0.1.1 (2024-11-18)


### PR DESCRIPTION
As mentioned in this Rye authors [blog](https://lucumr.pocoo.org/2024/2/15/rye-grows-with-uv/) rye will be a test field for uv which will be the main tool for package management. Now we just update rye version to newest where behaviour is set to be similar to uv which is first step to moving from rye to uv.